### PR TITLE
Handle missing theme data in getThemeById

### DIFF
--- a/qwc2/utils/ThemeUtils.js
+++ b/qwc2/utils/ThemeUtils.js
@@ -20,12 +20,15 @@ import LocaleUtils from './LocaleUtils';
 
 const ThemeUtils = {
     getThemeById(themes, id) {
-        for (let i = 0, n = themes.items.length; i < n; ++i) {
+        if (!themes) {
+            return null;
+        }
+        for (let i = 0, n = (themes.items || []).length; i < n; ++i) {
             if (themes.items[i].id === id) {
                 return themes.items[i];
             }
         }
-        for (let i = 0, n = themes.subdirs.length; i < n; ++i) {
+        for (let i = 0, n = (themes.subdirs || []).length; i < n; ++i) {
             const theme = this.getThemeById(themes.subdirs[i], id);
             if (theme) {
                 return theme;


### PR DESCRIPTION
## Summary
- avoid TypeError when themes list is empty by checking for missing items/subdirs

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a13683078832ab2208d36a59c0fc6