### PR TITLE
Add basic authentication for QWC2 UI

### DIFF
--- a/config/ui.htpasswd
+++ b/config/ui.htpasswd
@@ -1,0 +1,1 @@
+user:$apr1$f.P1fSDX$YuQmAKytkJ3670d13cofb0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - ./qwc2/prod:/usr/share/nginx/html
       - ./qwc2/nginx.conf:/etc/nginx/nginx.conf   # see below
       - ${PROJECT_DIR}:/io/data
+      - ./config/ui.htpasswd:/etc/nginx/.htpasswd:ro
     environment:
       # Internal URL for theme generation and health checks
       QGIS_SERVER_URL: http://nginx/

--- a/qwc2/nginx.conf
+++ b/qwc2/nginx.conf
@@ -9,6 +9,10 @@ http {
     listen 80;
     server_name _;
 
+    # Require authentication for accessing the UI
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
## Summary
- require credentials in qwc2 nginx configuration
- mount htpasswd file for authentication through docker-compose

## Testing
- `docker-compose config` *(fails: Named volume "C:\\Users\\Mark\\Downloads\\07 QGIS\\07 QGIS:/io/data" is used in service "qgis-server" but no declaration was found in the volumes section.)*

------
https://chatgpt.com/codex/tasks/task_e_689b58dd2a6c832aa01a5b7112edc6a7